### PR TITLE
Removing function-name dependency (due to non compliance with IE11/Edge)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var assert = require('nanoassert')
 var Nanocomponent = require('nanocomponent')
-var setName = require('function-name')
 
 var NAME = 'fun-component'
 var HOOKS = ['load', 'unload', 'beforerender', 'afterupdate', 'afterreorder']
@@ -13,13 +12,12 @@ module.exports.Context = Context
 function component (name, render) {
   if (typeof name === 'function') {
     render = name
-    name = Object.getOwnPropertyDescriptor(render, 'name').value || NAME
+    name = render.name || NAME
   }
 
   var middleware = []
   var context = new Context(name, render)
 
-  setName(renderer, name)
   function renderer () {
     var args = Array.prototype.slice.call(arguments)
 
@@ -33,6 +31,13 @@ function component (name, render) {
 
   Object.defineProperty(renderer, 'use', {
     get: function () { return use }
+  })
+
+  Object.defineProperty(renderer, 'name', {
+    value: name,
+    writable: false,
+    enumerable: false,
+    configurable: true
   })
 
   function use (fn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,12 +4388,6 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
-    "now": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/now/-/now-8.2.1.tgz",
-      "integrity": "sha512-mWAcycOrzBmOy7HjsRkcnDRzx87e6NMMN04xJdrveEkyYxcqc6s+2bgMWm7juXvhBl+cQBIpQM6VmOVUC2uWFQ==",
-      "dev": true
-    },
     "nugget": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2928,11 +2928,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "function-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/function-name/-/function-name-2.0.0.tgz",
-      "integrity": "sha1-X15Syz7vIuTnU4NFN/X4PTuLD84="
-    },
     "garnish": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/garnish/-/garnish-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "budo": "^10.0.4",
     "markdown-it": "^8.4.0",
     "nanomorph": "^5.1.3",
-    "now": "^8.2.1",
     "periodic-table": "0.0.8",
     "standard": "^10.0.3",
     "tape": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "tape-run": "^3.0.0"
   },
   "dependencies": {
-    "function-name": "^2.0.0",
     "nanoassert": "^1.1.0",
     "nanocomponent": "^6.4.2",
     "nanologger": "^1.3.0"


### PR DESCRIPTION
- Cleanup of the `function-name` in package.json / package-lock.json.
- Removed `function-name` require.
- Simple `Object.defineProperty` put in place of `function-name` call.

Issue reference: https://github.com/tornqvist/fun-component/issues/1